### PR TITLE
Add KeepAlive logic that auto-reconnects

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -275,7 +275,7 @@ private:
   void timer_callback() {
     auto packet = mWFT->readDataPacket();
     if (!packet.valid) {
-      //RCLCPP_WARN(get_logger(), "Skipping Invalid Packet");
+      RCLCPP_DEBUG(get_logger(), "Skipping Invalid Packet");
       return;
     }
     mIsAlive = true;


### PR DESCRIPTION
Test procedure:

1. Run F/T Sensor
2. Run the program: `ros2 run forque_sensor_hardware forque_sensor_hardware`
3. Verify successful initalization
4. Turn off the F/T sensor, verify that this prints the warning "KeepAlive Failed, re-init"
5. Turn on the F/T sensor, verify that, eventually, Initialization is successful (it may take a couple tries as the F/T sensor boots up.