### PR TITLE
Use a fixed local UDP port

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,8 @@ The Hardware Interface can connect to the F/T sensor via IP, publish its data as
 ## Sample Usage
 `ros2 run forque_sensor_hardware forque_sensor_hardware —ros-args -p host:=xxx.xxx.x.xx` (replace the x's with the F/T sensor's IP address)
 
-(See [the code](https://github.com/personalrobotics/forque_sensor_hardware/blob/2cfafda1f5aed56a0656895aaa47e7d58d98acad/src/main.cpp#L58) for a complete list of parameters)
+(See [the code](https://github.com/personalrobotics/forque_sensor_hardware/blob/b18c53c65557c9c37e235d307e40a5a14d349f6f/src/main.cpp#L67) for a complete list of parameters)
+
+## Troubleshooting
+
+Note that the F/T transmitter sometimes has an idiosynchracy where, if you request it starts streaming data to an IP address at a UDP port, and the UDP port is different from the one it started streaming to upon startup, it will close the old socket but not reopen a new one. Thus, if you launch this code and aren't receiving any data, the first thing to do is to stop the code, turn off the F/T transmitter, and then turn it back on. When it turns back on, it should automatically open a socket to the previously-requested IP address and port, which this code can then listen on.

--- a/include/forque_sensor_hardware/wireless_ft.h
+++ b/include/forque_sensor_hardware/wireless_ft.h
@@ -167,7 +167,7 @@ public:
   // Mostly for internal use
   bool telnetCommand(std::string & response, std::string command, unsigned int micros = 500000);
 
-  bool udpConfigure(std::string hostname, int port = DEFAULT_UDP_PORT);
+  bool udpConfigure(std::string hostname, int ft_port = DEFAULT_UDP_PORT, int local_port = DEFAULT_UDP_PORT);
   bool udpClose();
   bool udpStartStreaming();
   bool udpStopStreaming();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -139,9 +139,15 @@ public:
 
     param_desc.name = "udpport";
     param_desc.type = rclcpp::ParameterType::PARAMETER_INTEGER;
-    param_desc.description = "UDP Port for Packet Commands, Default 49152";
+    param_desc.description = "UDP Port on the F/T transmitter for Packet Commands, Default 49152";
     param_desc.read_only = true;
     declare_parameter("udpport", DEFAULT_UDP_PORT, param_desc);
+
+    param_desc.name = "local_udpport";
+    param_desc.type = rclcpp::ParameterType::PARAMETER_INTEGER;
+    param_desc.description = "UDP Port on the local machine for Packet Commands, Default 49152. If -1, assign any available port.";
+    param_desc.read_only = true;
+    declare_parameter("local_udpport", DEFAULT_UDP_PORT, param_desc);
 
     mCallbackHandle = add_on_set_parameters_callback(std::bind(
         &WirelessFTNode::parametersCallback, this, std::placeholders::_1));
@@ -180,9 +186,10 @@ public:
 
 bool init_udp() {
   auto host = get_parameter("host").get_parameter_value().get<std::string>();
-  auto udpport = get_parameter("udpport").get_parameter_value().get<int>();
+  auto ft_udpport = get_parameter("udpport").get_parameter_value().get<int>();
+  auto local_udpport = get_parameter("local_udpport").get_parameter_value().get<int>();
 
-  if (!mWFT->udpConfigure(host, udpport)) {
+  if (!mWFT->udpConfigure(host, ft_udpport, local_udpport)) {
     RCLCPP_ERROR(get_logger(), "Cannot connect to F/T UDP.");
     return false;
   }


### PR DESCRIPTION
# Description

Recently, our [F/T transmitter](https://www.ati-ia.com/app_content/documents/9610-05-1031.pdf) started having an issue where, when the UDP port it was streaming to changed, it would close the old socket but not reopen a new one. However, it does store the machine's IP address and the requested UDP port, and next time you turn it off and back on again, it by default starts streaming to that machine at that port.

Thus, this PR introduces a temporary fix, where the UDP socket opened on `lovelace` is always bounded to a fixed UDP port, which can be set with the `local_udpport` ROS2 param. This way, we receive UDP packets at the same port that the F/T transmitter will automatically send packets to upon startup. (Note: if you want to restore the old functionality of assigning to any available UDP port, set `local_udpport` to `-1`).

NOTE: Additional details of this bug, including `minicom` logs, are documented in [this subsection of the ADA wiki](https://github.com/personalrobotics/pr_docs/wiki/ADA#ft-code-doesnt-receive-udp-packets-from-the-wireless-ft-sensor).

# Testing

- [x] Verify the issue:
    - [x] Run the `main` branch of this repo. Verify that UDP packets aren't received.
- [x] Verify the fix:
    - [x] Run this branch of the repo. Verify that UDP packets are received. 
        - [ ] **Note**: if this is your first time running this branch fix after you ran `main`, the UDP port that the F/T transmitter stores is probably wrong. Thus, first run this code (it won't receive packets), then terminate it and turn off the F/T transmitter, then turn on the F/T transmitter (so it starts by streaming to the fixed port that this code is using), and then re-run this code.